### PR TITLE
Use DirtyCPU schedulers for NIFs

### DIFF
--- a/native/nimblelz4/src/lib.rs
+++ b/native/nimblelz4/src/lib.rs
@@ -5,7 +5,7 @@ use rustler::types::atom;
 use rustler::types::binary::{Binary, OwnedBinary};
 use rustler::{Encoder, Env, Error, Term};
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn compress<'a>(env: Env<'a>, iolist_to_compress: Term<'a>) -> Result<Term<'a>, Error> {
     let binary_to_compress: Binary = Binary::from_iolist(iolist_to_compress).unwrap();
     let compressed_slice = lz4_flex::compress(binary_to_compress.as_slice());
@@ -19,7 +19,7 @@ fn compress<'a>(env: Env<'a>, iolist_to_compress: Term<'a>) -> Result<Term<'a>, 
     Ok(erl_bin.release(env).encode(env))
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn decompress<'a>(
     env: Env<'a>,
     binary_to_decompress: Binary,


### PR DESCRIPTION
The official [Erlang documentation](https://www.erlang.org/doc/man/erl_nif.html#lengthy_work) suggests that NIFs should not take longer than 1 ms to execute. Otherwise calls to native functions starting to interfere with the BEAM schedulers.

With compression and decompression execution time is directly dependent on the input size. I used existing benchmarks and found that **1 ms** is exceeded at approximately **190Kb** for compression and **260Kb** for decompression. My local machine has the following specs:
```
Operating System: macOS
CPU Information: Apple M2 Max
Number of Available Cores: 12
Available memory: 32 GB
Elixir 1.14.5
Erlang 25.3.2.2
```

A separate set of schedulers comes with a penalty of around **10us** per call if we can believe [this](https://medium.com/@jlouis666/erlang-dirty-scheduler-overhead-6e1219dcc7) article. Again, if we follow the author's footsteps and assume that overhear becomes bearable when it takes < 10% of execution time we will get our threshold around **16Kb** for compression and **32Kb** for decompression.

Taking into consideration that an average running environment (e.g. Kubernetes pod) has way less computational resources than my laptop, I believe that we can safely enable Dirty CPU Bound Schedulers since they will better serve overwhelming majority of use cases.