### PR TITLE
update lz4_flex crate to v0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,21 @@ NIMBLELZ4_FORCE_BUILD=true mix deps.compile
 
 You can compress and decompress data.
 
+[Block format](https://github.com/lz4/lz4/blob/dev/doc/lz4_Block_format.md):
+
 ```elixir
 iex> uncompressed = :crypto.strong_rand_bytes(10)
 iex> compressed = NimbleLZ4.compress(uncompressed)
 iex> {:ok, ^uncompressed} = NimbleLZ4.decompress(compressed, _uncompressed_size = 10)
+true
+```
+
+[Frame format](https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md) ([self-contained](https://android.googlesource.com/platform/external/lz4/+/HEAD/doc/lz4_Block_format.md#metadata)):
+
+```elixir
+iex> uncompressed = :crypto.strong_rand_bytes(10_000)
+iex> compressed = NimbleLZ4.compress_frame(uncompressed)
+iex> {:ok, ^uncompressed} = NimbleLZ4.decompress_frame(compressed)
 true
 ```
 

--- a/native/nimblelz4/Cargo.lock
+++ b/native/nimblelz4/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lz4_flex"
-version = "0.9.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42c51df9d8d4842336c835df1d85ed447c4813baa237d033d95128bf5552ad8a"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
  "twox-hash",
 ]

--- a/native/nimblelz4/Cargo.toml
+++ b/native/nimblelz4/Cargo.toml
@@ -14,4 +14,4 @@ rustler = { version = "0.29", default-features = false, features = [
     "derive",
     "nif_version_2_15",
 ] }
-lz4_flex = { version = "0.9.0" }
+lz4_flex = { version = "0.11.0" }

--- a/native/nimblelz4/src/lib.rs
+++ b/native/nimblelz4/src/lib.rs
@@ -8,7 +8,7 @@ use rustler::{Encoder, Env, Error, Term};
 #[rustler::nif(schedule = "DirtyCpu")]
 fn compress<'a>(env: Env<'a>, iolist_to_compress: Term<'a>) -> Result<Term<'a>, Error> {
     let binary_to_compress: Binary = Binary::from_iolist(iolist_to_compress).unwrap();
-    let compressed_slice = lz4_flex::compress(binary_to_compress.as_slice());
+    let compressed_slice = lz4_flex::block::compress(binary_to_compress.as_slice());
 
     let mut erl_bin: OwnedBinary = OwnedBinary::new(compressed_slice.len()).unwrap();
 
@@ -42,7 +42,7 @@ fn decompress<'a>(
     binary_to_decompress: Binary,
     uncompressed_size: usize,
 ) -> Result<Term<'a>, Error> {
-    match lz4_flex::decompress(binary_to_decompress.as_slice(), uncompressed_size) {
+    match lz4_flex::block::decompress(binary_to_decompress.as_slice(), uncompressed_size) {
         Ok(decompressed_vec) => {
             let mut erl_bin: OwnedBinary = OwnedBinary::new(decompressed_vec.len()).unwrap();
             erl_bin

--- a/test/nimble_lz4_test.exs
+++ b/test/nimble_lz4_test.exs
@@ -54,7 +54,7 @@ defmodule NimbleLZ4Test do
     end
 
     test "with iodata" do
-      assert NimbleLZ4.compress_frame([]) == ""
+      assert NimbleLZ4.compress_frame([]) == "\x04\"M\x18`@\x82\0\0\0\0"
 
       assert NimbleLZ4.compress_frame([?f, [[[?o]]], "o"]) ==
                "\x04\"M\x18`@\x82\x03\0\0\x80foo\0\0\0\0"
@@ -67,8 +67,8 @@ defmodule NimbleLZ4Test do
     end
 
     test "with the wrong uncompressed size" do
-      assert {:error, message} = NimbleLZ4.decompress(NimbleLZ4.compress("foo"), 6)
-      assert message == "the expected decompressed size differs, actual 3, expected 6"
+      assert {:error, message} = NimbleLZ4.decompress(NimbleLZ4.compress("foo"), 2)
+      assert message == "provided output is too small for the decompressed data, actual 2, expected 3"
     end
   end
 

--- a/test/nimble_lz4_test.exs
+++ b/test/nimble_lz4_test.exs
@@ -68,7 +68,9 @@ defmodule NimbleLZ4Test do
 
     test "with the wrong uncompressed size" do
       assert {:error, message} = NimbleLZ4.decompress(NimbleLZ4.compress("foo"), 2)
-      assert message == "provided output is too small for the decompressed data, actual 2, expected 3"
+
+      assert message ==
+               "provided output is too small for the decompressed data, actual 2, expected 3"
     end
   end
 


### PR DESCRIPTION
This PR updates the `lz4_flex` rust crate to the latest version (0.11), update tests to match the changes in behavior since 0.9 and adds a little example in the readme on how to use the recent frame format functions

Details:

* In `native/nimblelz4/src/lib.rs` added `block::` for the `compress/decompress` functions, because the export of those is [deprecated in 0.11](https://github.com/PSeitz/lz4_flex/blob/0.11/src/lib.rs#L102)
* Modified empty frame encoding test to account for https://github.com/PSeitz/lz4_flex/pull/120 part of 0.11
* Modified incorrect size in block decoding test to account for https://github.com/PSeitz/lz4_flex/pull/78 part of 0.11