### PR TITLE
Fix module name in the Mixfile

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule NimbleLz4.MixProject do
+defmodule NimbleLZ4.MixProject do
   use Mix.Project
 
   @version "1.1.0"


### PR DESCRIPTION
👋 

This PR removes inconsistency in module names between MixProject and actual code.

Before this PR:

```elixir
iex> Nimble<tab>
#==> NimbleLZ4        NimbleLz4        NimbleOptions    NimblePool
```

After this PR:

```elixir
iex> Nimble<tab>
#==> NimbleLZ4        NimbleOptions    NimblePool
```