### PR TITLE
Add a streaming compression/decompression API (closes #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.0
+
+  * Add a streaming API for compressing and decompressing large or incremental payloads using the [LZ4 frame format](https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md), with memory usage bounded regardless of the total size of the data:
+    * High-level: `NimbleLZ4.compress_stream/1` and `NimbleLZ4.decompress_stream/1`, which work with any `Enumerable`.
+    * Low-level: `NimbleLZ4.compress_stream_new/0`, `NimbleLZ4.compress_stream_update/2`, `NimbleLZ4.compress_stream_finish/1`, and their `decompress_*` counterparts.
+
 ## v1.1.0
 
   * Add `NimbleLZ4.compress_frame/1` and `NimbleLZ4.decompress_frame/1` to use with the [LZ4 frame format](https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md).

--- a/README.md
+++ b/README.md
@@ -54,5 +54,31 @@ iex> {:ok, ^uncompressed} = NimbleLZ4.decompress_frame(compressed)
 true
 ```
 
+### Streaming
+
+For large payloads or data that arrives incrementally, you can compress and
+decompress lazily without holding everything in memory. `compress_stream/1` and
+`decompress_stream/1` turn an enumerable of `iodata` chunks into a lazy stream of
+binary chunks (using the LZ4 frame format):
+
+```elixir
+# Compress a large file chunk-by-chunk.
+"large_file"
+|> File.stream!(2048, [])
+|> NimbleLZ4.compress_stream()
+|> Stream.into(File.stream!("large_file.lz4"))
+|> Stream.run()
+
+# And decompress it back.
+"large_file.lz4"
+|> File.stream!(2048, [])
+|> NimbleLZ4.decompress_stream()
+|> Enum.into("")
+```
+
+There's also a lower-level resource-based API
+(`compress_stream_new/0`, `compress_stream_update/2`, `compress_stream_finish/1`
+and their `decompress_*` counterparts) for finer-grained control.
+
 [LZ4]: https://github.com/lz4/lz4
 [RustlerPrecompiled]: https://github.com/philss/rustler_precompiled

--- a/lib/nimble_lz4.ex
+++ b/lib/nimble_lz4.ex
@@ -2,8 +2,40 @@ defmodule NimbleLZ4 do
   @moduledoc """
   [LZ4](https://github.com/lz4/lz4) compression and decompression.
 
-  This functionality is built on top of native (Rust) NIFs. There is no
-  streaming functionality, everything is done in memory.
+  This functionality is built on top of native (Rust) NIFs.
+
+  ## One-shot vs Streaming
+
+  For small payloads that fit comfortably in memory, use the one-shot functions
+  (`compress/1`, `decompress/2`, `compress_frame/1`, `decompress_frame/1`), which
+  compress or decompress a whole binary at once.
+
+  For large payloads, or data that arrives incrementally (such as a file being
+  read in chunks or a network stream), use the **streaming API**. It uses the
+  [LZ4 frame format](https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md)
+  and keeps memory usage bounded regardless of the total size of the data.
+
+  The easiest way to use it is through `compress_stream/1` and
+  `decompress_stream/1`, which turn an enumerable of `t:iodata/0` chunks into a
+  lazy stream of binary chunks:
+
+      "large_file"
+      |> File.stream!(2048, [])
+      |> NimbleLZ4.compress_stream()
+      |> Stream.into(File.stream!("large_file.lz4"))
+      |> Stream.run()
+
+  And to decompress it back:
+
+      "large_file.lz4"
+      |> File.stream!(2048, [])
+      |> NimbleLZ4.decompress_stream()
+      |> Enum.into("")
+
+  If you need finer-grained control over the lifecycle of a stream (for example,
+  to interleave compression with other work), use the lower-level
+  `compress_stream_new/0`, `compress_stream_update/2`, and
+  `compress_stream_finish/1` functions (and their `decompress_*` counterparts).
 
   ## Uncompressed Size
 
@@ -64,6 +96,176 @@ defmodule NimbleLZ4 do
   @doc since: "1.1.0"
   @spec decompress_frame(binary()) :: {:ok, binary()} | {:error, term()}
   def decompress_frame(_binary) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  @typedoc """
+  An opaque handle to a streaming compressor, created by `compress_stream_new/0`.
+  """
+  @typedoc since: "1.2.0"
+  @opaque compressor() :: reference()
+
+  @typedoc """
+  An opaque handle to a streaming decompressor, created by
+  `decompress_stream_new/0`.
+  """
+  @typedoc since: "1.2.0"
+  @opaque decompressor() :: reference()
+
+  @doc """
+  Lazily compresses an enumerable of `t:iodata/0` chunks into a stream of
+  compressed binary chunks.
+
+  The resulting stream produces a single [LZ4
+  frame](https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md). Memory
+  usage stays bounded regardless of the total size of the input, which makes
+  this suitable for compressing large files or network streams.
+
+  Some emitted chunks may be empty binaries: LZ4 buffers data internally and
+  only emits a compressed block once it has accumulated enough input.
+
+  ## Examples
+
+      iex> chunks = ["hello ", "world"]
+      iex> compressed = chunks |> NimbleLZ4.compress_stream() |> Enum.into("")
+      iex> NimbleLZ4.decompress_frame(compressed)
+      {:ok, "hello world"}
+
+  """
+  @doc since: "1.2.0"
+  @spec compress_stream(Enumerable.t()) :: Enumerable.t()
+  def compress_stream(enumerable) do
+    Stream.transform(
+      enumerable,
+      fn -> compress_stream_new() end,
+      fn chunk, compressor -> {[compress_stream_update(compressor, chunk)], compressor} end,
+      fn compressor -> {[compress_stream_finish(compressor)], compressor} end,
+      fn _compressor -> :ok end
+    )
+  end
+
+  @doc """
+  Lazily decompresses an enumerable of `t:iodata/0` chunks (a single LZ4 frame,
+  possibly split across chunks) into a stream of decompressed binary chunks.
+
+  This is the counterpart of `compress_stream/1`. The chunks of the input
+  enumerable don't need to align with the frame's internal block boundaries: you
+  can feed the frame in arbitrarily-sized pieces.
+
+  Raises a `RuntimeError` if the data is not a valid LZ4 frame.
+
+  ## Examples
+
+      iex> compressed = NimbleLZ4.compress_frame("hello world")
+      iex> [compressed] |> NimbleLZ4.decompress_stream() |> Enum.into("")
+      "hello world"
+
+  """
+  @doc since: "1.2.0"
+  @spec decompress_stream(Enumerable.t()) :: Enumerable.t()
+  def decompress_stream(enumerable) do
+    Stream.transform(
+      enumerable,
+      fn -> decompress_stream_new() end,
+      fn chunk, decompressor ->
+        {[unwrap_decompressed(decompress_stream_update(decompressor, chunk))], decompressor}
+      end,
+      fn decompressor ->
+        {[unwrap_decompressed(decompress_stream_finish(decompressor))], decompressor}
+      end,
+      fn _decompressor -> :ok end
+    )
+  end
+
+  defp unwrap_decompressed({:ok, binary}), do: binary
+
+  defp unwrap_decompressed({:error, reason}) do
+    raise "failed to decompress LZ4 stream: #{reason}"
+  end
+
+  @doc """
+  Creates a new streaming compressor.
+
+  Returns an opaque handle to be used with `compress_stream_update/2` and
+  `compress_stream_finish/1`. The handle is backed by a native resource that is
+  automatically cleaned up when it is garbage-collected, so it is safe to
+  discard a compressor without calling `compress_stream_finish/1` (although doing
+  so means the produced frame will be incomplete).
+
+  See `compress_stream/1` for a higher-level API.
+  """
+  @doc since: "1.2.0"
+  @spec compress_stream_new() :: compressor()
+  def compress_stream_new do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  @doc """
+  Feeds a chunk of `t:iodata/0` into a streaming compressor.
+
+  Returns a binary with the compressed data produced so far. This may be an
+  empty binary if LZ4 has buffered the input internally without emitting a
+  complete block yet.
+  """
+  @doc since: "1.2.0"
+  @spec compress_stream_update(compressor(), iodata()) :: binary()
+  def compress_stream_update(_compressor, _iodata) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  @doc """
+  Finalizes a streaming compressor.
+
+  Flushes any remaining buffered data and writes the frame's end marker,
+  returning the final binary chunk. After this call the compressor must not be
+  used again.
+  """
+  @doc since: "1.2.0"
+  @spec compress_stream_finish(compressor()) :: binary()
+  def compress_stream_finish(_compressor) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  @doc """
+  Creates a new streaming decompressor.
+
+  Returns an opaque handle to be used with `decompress_stream_update/2` and
+  `decompress_stream_finish/1`. The handle is backed by a native resource that
+  is automatically cleaned up when it is garbage-collected.
+
+  See `decompress_stream/1` for a higher-level API.
+  """
+  @doc since: "1.2.0"
+  @spec decompress_stream_new() :: decompressor()
+  def decompress_stream_new do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  @doc """
+  Feeds a chunk of compressed `t:iodata/0` into a streaming decompressor.
+
+  Returns `{:ok, binary}` with the decompressed data available so far, which may
+  be an empty binary if the decompressor needs more input before it can emit the
+  next block. Returns `{:error, reason}` if the data is not a valid LZ4 frame.
+  """
+  @doc since: "1.2.0"
+  @spec decompress_stream_update(decompressor(), iodata()) ::
+          {:ok, binary()} | {:error, term()}
+  def decompress_stream_update(_decompressor, _iodata) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  @doc """
+  Finalizes a streaming decompressor.
+
+  Signals that no more input is coming and returns `{:ok, binary}` with any
+  remaining decompressed data. Returns `{:error, reason}` if the frame was
+  incomplete or otherwise invalid. After this call the decompressor must not be
+  used again.
+  """
+  @doc since: "1.2.0"
+  @spec decompress_stream_finish(decompressor()) :: {:ok, binary()} | {:error, term()}
+  def decompress_stream_finish(_decompressor) do
     :erlang.nif_error(:nif_not_loaded)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule NimbleLZ4.MixProject do
   use Mix.Project
 
-  @version "1.1.0"
+  @version "1.2.0"
   @source_url "https://github.com/whatyouhide/nimble_lz4"
 
   def project do

--- a/native/nimblelz4/src/lib.rs
+++ b/native/nimblelz4/src/lib.rs
@@ -3,20 +3,17 @@ extern crate rustler;
 
 use rustler::types::atom;
 use rustler::types::binary::{Binary, OwnedBinary};
-use rustler::{Encoder, Env, Error, Term};
+use rustler::{Encoder, Env, Error, Resource, ResourceArc, Term};
+use std::io::{Read, Write};
+use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+use std::sync::Mutex;
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn compress<'a>(env: Env<'a>, iolist_to_compress: Term<'a>) -> Result<Term<'a>, Error> {
     let binary_to_compress: Binary = Binary::from_iolist(iolist_to_compress).unwrap();
     let compressed_slice = lz4_flex::block::compress(binary_to_compress.as_slice());
 
-    let mut erl_bin: OwnedBinary = OwnedBinary::new(compressed_slice.len()).unwrap();
-
-    erl_bin
-        .as_mut_slice()
-        .copy_from_slice(compressed_slice.as_slice());
-
-    Ok(erl_bin.release(env).encode(env))
+    Ok(binary_from_slice(env, &compressed_slice).encode(env))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
@@ -27,13 +24,7 @@ fn compress_frame<'a>(env: Env<'a>, iolist_to_compress: Term<'a>) -> Result<Term
     std::io::Write::write(&mut compressor, binary_to_compress.as_slice()).unwrap();
     let compressed = compressor.finish().unwrap();
 
-    let mut erl_bin: OwnedBinary = OwnedBinary::new(compressed.len()).unwrap();
-
-    erl_bin
-        .as_mut_slice()
-        .copy_from_slice(compressed.as_slice());
-
-    Ok(erl_bin.release(env).encode(env))
+    Ok(binary_from_slice(env, &compressed).encode(env))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
@@ -44,12 +35,7 @@ fn decompress<'a>(
 ) -> Result<Term<'a>, Error> {
     match lz4_flex::block::decompress(binary_to_decompress.as_slice(), uncompressed_size) {
         Ok(decompressed_vec) => {
-            let mut erl_bin: OwnedBinary = OwnedBinary::new(decompressed_vec.len()).unwrap();
-            erl_bin
-                .as_mut_slice()
-                .copy_from_slice(decompressed_vec.as_slice());
-
-            Ok((atom::ok(), erl_bin.release(env)).encode(env))
+            Ok((atom::ok(), binary_from_slice(env, &decompressed_vec)).encode(env))
         }
         Err(decompress_err) => Ok((atom::error(), decompress_err.to_string()).encode(env)),
     }
@@ -60,17 +46,236 @@ fn decompress_frame<'a>(env: Env<'a>, binary_to_decompress: Binary) -> Result<Te
     let mut decompressed_buf: Vec<u8> = Vec::new();
     let mut decompressor = lz4_flex::frame::FrameDecoder::new(binary_to_decompress.as_slice());
 
-    match std::io::Read::read_to_end(&mut decompressor, &mut decompressed_buf) {
-        Ok(_) => {
-            let mut erl_bin: OwnedBinary = OwnedBinary::new(decompressed_buf.len()).unwrap();
-            erl_bin
-                .as_mut_slice()
-                .copy_from_slice(decompressed_buf.as_slice());
-
-            Ok((atom::ok(), erl_bin.release(env)).encode(env))
-        }
+    match decompressor.read_to_end(&mut decompressed_buf) {
+        Ok(_) => Ok((atom::ok(), binary_from_slice(env, &decompressed_buf)).encode(env)),
         Err(e) => Ok((atom::error(), e.to_string()).encode(env)),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming compression (LZ4 frame format)
+// ---------------------------------------------------------------------------
+//
+// A `FrameEncoder` writing into an in-memory `Vec<u8>` is held alive in a NIF
+// resource. Each `compress_stream_update` call writes a chunk into the encoder
+// and drains whatever complete compressed blocks the encoder has produced so
+// far. `compress_stream_finish` flushes the remaining buffered data and the
+// frame's end marker. This keeps memory usage bounded by a single block,
+// regardless of the total size of the stream.
+
+struct CompressStream {
+    encoder: Mutex<Option<lz4_flex::frame::FrameEncoder<Vec<u8>>>>,
+}
+
+#[rustler::resource_impl]
+impl Resource for CompressStream {}
+
+#[rustler::nif]
+fn compress_stream_new() -> ResourceArc<CompressStream> {
+    ResourceArc::new(CompressStream {
+        encoder: Mutex::new(Some(lz4_flex::frame::FrameEncoder::new(Vec::new()))),
+    })
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+fn compress_stream_update<'a>(
+    env: Env<'a>,
+    resource: ResourceArc<CompressStream>,
+    iodata: Term<'a>,
+) -> Result<Term<'a>, Error> {
+    let data: Binary = Binary::from_iolist(iodata)?;
+
+    let mut guard = resource.encoder.lock().unwrap();
+    let encoder = guard
+        .as_mut()
+        .ok_or_else(|| Error::RaiseTerm(Box::new("stream already finished")))?;
+
+    encoder
+        .write_all(data.as_slice())
+        .map_err(|e| Error::Term(Box::new(e.to_string())))?;
+
+    let drained = std::mem::take(encoder.get_mut());
+    Ok(binary_from_slice(env, &drained).encode(env))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+fn compress_stream_finish<'a>(
+    env: Env<'a>,
+    resource: ResourceArc<CompressStream>,
+) -> Result<Term<'a>, Error> {
+    let mut guard = resource.encoder.lock().unwrap();
+    let encoder = guard
+        .take()
+        .ok_or_else(|| Error::RaiseTerm(Box::new("stream already finished")))?;
+
+    let final_bytes = encoder
+        .finish()
+        .map_err(|e| Error::Term(Box::new(e.to_string())))?;
+
+    Ok(binary_from_slice(env, &final_bytes).encode(env))
+}
+
+// ---------------------------------------------------------------------------
+// Streaming decompression (LZ4 frame format)
+// ---------------------------------------------------------------------------
+//
+// `lz4_flex`'s `FrameDecoder` is pull-based (it reads from an `io::Read`) and
+// uses `read_exact` internally, so it cannot be fed partial blocks and resumed.
+// To turn it into a push-based API we run the decoder on a dedicated thread
+// that reads compressed bytes from a channel and writes decompressed chunks
+// back to another channel. `decompress_stream_update` feeds compressed bytes
+// and drains any decompressed output that is ready; `decompress_stream_finish`
+// closes the input (signalling EOF) and blocks until the thread has flushed
+// everything. Output that is not ready during an `update` (because the decoder
+// is waiting for the rest of a block) is delivered by a later `update` or by
+// `finish` — the concatenation of all returned chunks is the full plaintext.
+
+enum DecompressMsg {
+    Chunk(Vec<u8>),
+    Error(String),
+}
+
+struct DecompressStream {
+    input: Mutex<Option<Sender<Vec<u8>>>>,
+    output: Mutex<Receiver<DecompressMsg>>,
+}
+
+#[rustler::resource_impl]
+impl Resource for DecompressStream {}
+
+/// `io::Read` backed by a channel of compressed chunks. Blocks waiting for more
+/// input so the `FrameDecoder`'s `read_exact` calls can always be satisfied, and
+/// reports EOF once the sending side is dropped.
+struct ChannelReader {
+    rx: Receiver<Vec<u8>>,
+    buf: Vec<u8>,
+    pos: usize,
+}
+
+impl Read for ChannelReader {
+    fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+        while self.pos >= self.buf.len() {
+            match self.rx.recv() {
+                Ok(chunk) => {
+                    self.buf = chunk;
+                    self.pos = 0;
+                }
+                // Sender dropped: no more input is coming, signal EOF.
+                Err(_) => return Ok(0),
+            }
+        }
+
+        let n = std::cmp::min(out.len(), self.buf.len() - self.pos);
+        out[..n].copy_from_slice(&self.buf[self.pos..self.pos + n]);
+        self.pos += n;
+        Ok(n)
+    }
+}
+
+#[rustler::nif]
+fn decompress_stream_new() -> ResourceArc<DecompressStream> {
+    let (input_tx, input_rx) = mpsc::channel::<Vec<u8>>();
+    let (output_tx, output_rx) = mpsc::channel::<DecompressMsg>();
+
+    std::thread::spawn(move || {
+        let reader = ChannelReader {
+            rx: input_rx,
+            buf: Vec::new(),
+            pos: 0,
+        };
+        let mut decoder = lz4_flex::frame::FrameDecoder::new(reader);
+        let mut buf = vec![0u8; 64 * 1024];
+
+        loop {
+            match decoder.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if output_tx
+                        .send(DecompressMsg::Chunk(buf[..n].to_vec()))
+                        .is_err()
+                    {
+                        // Receiver dropped (resource gone): stop working.
+                        break;
+                    }
+                }
+                Err(e) => {
+                    let _ = output_tx.send(DecompressMsg::Error(e.to_string()));
+                    break;
+                }
+            }
+        }
+    });
+
+    ResourceArc::new(DecompressStream {
+        input: Mutex::new(Some(input_tx)),
+        output: Mutex::new(output_rx),
+    })
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+fn decompress_stream_update<'a>(
+    env: Env<'a>,
+    resource: ResourceArc<DecompressStream>,
+    iodata: Term<'a>,
+) -> Result<Term<'a>, Error> {
+    let data: Binary = Binary::from_iolist(iodata)?;
+
+    {
+        let guard = resource.input.lock().unwrap();
+        match guard.as_ref() {
+            Some(tx) => {
+                let _ = tx.send(data.as_slice().to_vec());
+            }
+            None => return Ok((atom::error(), "stream already finished").encode(env)),
+        }
+    }
+
+    // Drain whatever output is ready without blocking.
+    let output = resource.output.lock().unwrap();
+    let mut collected: Vec<u8> = Vec::new();
+    loop {
+        match output.try_recv() {
+            Ok(DecompressMsg::Chunk(chunk)) => collected.extend_from_slice(&chunk),
+            Ok(DecompressMsg::Error(e)) => return Ok((atom::error(), e).encode(env)),
+            Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => break,
+        }
+    }
+
+    Ok((atom::ok(), binary_from_slice(env, &collected)).encode(env))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+fn decompress_stream_finish<'a>(
+    env: Env<'a>,
+    resource: ResourceArc<DecompressStream>,
+) -> Result<Term<'a>, Error> {
+    {
+        let mut guard = resource.input.lock().unwrap();
+        // Dropping the sender signals EOF to the decoder thread.
+        if guard.take().is_none() {
+            return Ok((atom::error(), "stream already finished").encode(env));
+        }
+    }
+
+    // Block until the thread has flushed everything and exited.
+    let output = resource.output.lock().unwrap();
+    let mut collected: Vec<u8> = Vec::new();
+    loop {
+        match output.recv() {
+            Ok(DecompressMsg::Chunk(chunk)) => collected.extend_from_slice(&chunk),
+            Ok(DecompressMsg::Error(e)) => return Ok((atom::error(), e).encode(env)),
+            // Channel disconnected: thread is done.
+            Err(_) => break,
+        }
+    }
+
+    Ok((atom::ok(), binary_from_slice(env, &collected)).encode(env))
+}
+
+fn binary_from_slice<'a>(env: Env<'a>, bytes: &[u8]) -> Term<'a> {
+    let mut erl_bin: OwnedBinary = OwnedBinary::new(bytes.len()).unwrap();
+    erl_bin.as_mut_slice().copy_from_slice(bytes);
+    erl_bin.release(env).encode(env)
 }
 
 fn load(_: Env, _: Term) -> bool {

--- a/test/nimble_lz4_test.exs
+++ b/test/nimble_lz4_test.exs
@@ -2,6 +2,8 @@ defmodule NimbleLZ4Test do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
+  doctest NimbleLZ4
+
   property "compress + uncompress are circular" do
     check all binary <- binary() do
       assert {:ok, ^binary} =
@@ -82,5 +84,128 @@ defmodule NimbleLZ4Test do
     test "decompresses correctly" do
       assert {:ok, "foo"} = NimbleLZ4.decompress_frame("\x04\"M\x18`@\x82\x03\0\0\x80foo\0\0\0\0")
     end
+  end
+
+  describe "streaming" do
+    property "compress_stream + decompress_stream are circular" do
+      check all chunks <- list_of(binary()) do
+        original = IO.iodata_to_binary(chunks)
+
+        roundtripped =
+          chunks
+          |> NimbleLZ4.compress_stream()
+          |> NimbleLZ4.decompress_stream()
+          |> Enum.into("")
+
+        assert roundtripped == original
+      end
+    end
+
+    property "streamed compression is readable by the one-shot frame decompressor" do
+      check all chunks <- list_of(binary()) do
+        original = IO.iodata_to_binary(chunks)
+
+        compressed =
+          chunks
+          |> NimbleLZ4.compress_stream()
+          |> Enum.into("")
+
+        assert {:ok, ^original} = NimbleLZ4.decompress_frame(compressed)
+      end
+    end
+
+    property "one-shot compressed frame is readable by the streaming decompressor" do
+      check all binary <- binary(), chunk_size <- integer(1..32) do
+        compressed = NimbleLZ4.compress_frame(binary)
+
+        decompressed =
+          compressed
+          |> chunk_binary(chunk_size)
+          |> NimbleLZ4.decompress_stream()
+          |> Enum.into("")
+
+        assert decompressed == binary
+      end
+    end
+
+    test "round-trips a large payload spanning many frame blocks" do
+      original = :crypto.strong_rand_bytes(5_000_000)
+
+      roundtripped =
+        original
+        |> chunk_binary(4096)
+        |> NimbleLZ4.compress_stream()
+        |> NimbleLZ4.decompress_stream()
+        |> Enum.into("")
+
+      assert roundtripped == original
+    end
+
+    test "compress_stream/1 accepts iodata chunks" do
+      compressed =
+        [[?f], "o", [[?o]]]
+        |> NimbleLZ4.compress_stream()
+        |> Enum.into("")
+
+      assert {:ok, "foo"} = NimbleLZ4.decompress_frame(compressed)
+    end
+
+    test "low-level compressor API works across many updates" do
+      compressor = NimbleLZ4.compress_stream_new()
+
+      compressed =
+        for i <- 1..1000, into: "" do
+          NimbleLZ4.compress_stream_update(compressor, "chunk #{i} ")
+        end
+
+      compressed = compressed <> NimbleLZ4.compress_stream_finish(compressor)
+
+      expected = for i <- 1..1000, into: "", do: "chunk #{i} "
+      assert {:ok, ^expected} = NimbleLZ4.decompress_frame(compressed)
+    end
+
+    test "low-level decompressor API works across many updates" do
+      expected = for i <- 1..1000, into: "", do: "chunk #{i} "
+      compressed = NimbleLZ4.compress_frame(expected)
+
+      decompressor = NimbleLZ4.decompress_stream_new()
+
+      decompressed =
+        compressed
+        |> chunk_binary(7)
+        |> Enum.reduce("", fn chunk, acc ->
+          assert {:ok, data} = NimbleLZ4.decompress_stream_update(decompressor, chunk)
+          acc <> data
+        end)
+
+      assert {:ok, tail} = NimbleLZ4.decompress_stream_finish(decompressor)
+      assert decompressed <> tail == expected
+    end
+
+    test "decompress_stream/1 raises on invalid data" do
+      assert_raise RuntimeError, ~r/failed to decompress LZ4 stream/, fn ->
+        ["not a valid lz4 frame at all"]
+        |> NimbleLZ4.decompress_stream()
+        |> Enum.into("")
+      end
+    end
+
+    test "decompress_stream_finish/1 returns an error on a truncated frame" do
+      compressed = NimbleLZ4.compress_frame(:crypto.strong_rand_bytes(10_000))
+      truncated = binary_part(compressed, 0, div(byte_size(compressed), 2))
+
+      decompressor = NimbleLZ4.decompress_stream_new()
+      assert {:ok, _} = NimbleLZ4.decompress_stream_update(decompressor, truncated)
+      assert {:error, _reason} = NimbleLZ4.decompress_stream_finish(decompressor)
+    end
+  end
+
+  defp chunk_binary(binary, _size) when byte_size(binary) == 0, do: []
+
+  defp chunk_binary(binary, size) when byte_size(binary) <= size, do: [binary]
+
+  defp chunk_binary(binary, size) do
+    <<chunk::binary-size(^size), rest::binary>> = binary
+    [chunk | chunk_binary(rest, size)]
   end
 end


### PR DESCRIPTION
Closes #13.

## What

Adds a **streaming API** built on the LZ4 frame format, so large or
incrementally-arriving payloads can be (de)compressed without materializing
everything in memory.

### High-level (works with any `Enumerable`)

```elixir
"large_file"
|> File.stream!(2048, [])
|> NimbleLZ4.compress_stream()
|> Stream.into(File.stream!("large_file.lz4"))
|> Stream.run()

"large_file.lz4"
|> File.stream!(2048, [])
|> NimbleLZ4.decompress_stream()
|> Enum.into("")
```

### Low-level (resource handles, for finer control)

`compress_stream_new/0`, `compress_stream_update/2`, `compress_stream_finish/1`
and their `decompress_*` counterparts.

## How

- **Compression** keeps a `FrameEncoder<Vec<u8>>` alive in a NIF resource and
  drains completed compressed blocks on each `update`; `finish` writes the
  remaining buffered data plus the frame end marker. Memory stays bounded to a
  single block.
- **Decompression**: `lz4_flex`'s `FrameDecoder` is pull-based and uses
  `read_exact` internally, so it can't be fed partial blocks and resumed. It's
  driven on a dedicated thread that reads compressed bytes from a channel and
  pushes decompressed chunks back, giving a push-based incremental API. The
  resource (and thread) are cleaned up automatically on GC.

## Tests

Property tests for round-tripping and cross-compatibility with the existing
one-shot `compress_frame/decompress_frame`, plus unit tests covering iodata
input, many small updates, a 5 MB multi-block payload, and error handling for
invalid/truncated frames. Full suite (23 tests incl. doctests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)